### PR TITLE
FIX: Custom Listing Template not working properly with checkbox and generator

### DIFF
--- a/includes/blocks/render/checkbox-field-render.php
+++ b/includes/blocks/render/checkbox-field-render.php
@@ -89,7 +89,7 @@ class Checkbox_Field_Render extends Base_Select_Radio_Check {
 		$html .= apply_filters(
 			'jet-form-builder/render/checkbox-field/option',
 			$item,
-			$value,
+			$val,
 			$option,
 			$this
 		);


### PR DESCRIPTION
https://github.com/Crocoblock/jetformbuilder/blob/main/includes/blocks/render/checkbox-field-render.php#L57-L63 тут якщо опція це масив то у $val записується значення опції, її як я розумію і треба потім використовувати у фільтрі (інакше чекбокс поле ламається https://prnt.sc/V_i3290QDQHh ; якщо виправити то все ок https://prnt.sc/rN5EDmP0oHXh)