### PR TITLE
Add form ID option

### DIFF
--- a/compatibility/elementor/widgets/form.php
+++ b/compatibility/elementor/widgets/form.php
@@ -1128,6 +1128,18 @@ class Form extends Widget_Base implements Widget_Base_It {
 		);
 
 		$this->add_control(
+			'form_id_custom',
+			array(
+				'label'       => __( 'Form ID', 'jet-form-builder' ),
+				'type'        => Controls_Manager::TEXT,
+				'default'     => '',
+				'label_block' => false,
+				'description' => __( 'Note: This will override the `Choose Form` field', 'jet-form-builder' ),
+				'dynamic'     => array( 'active' => true, ),
+			)
+		);
+
+		$this->add_control(
 			'fields_layout',
 			array(
 				'label'   => __( 'Fields Layout', 'jet-form-builder' ),

--- a/compatibility/elementor/widgets/form.php
+++ b/compatibility/elementor/widgets/form.php
@@ -1135,7 +1135,7 @@ class Form extends Widget_Base implements Widget_Base_It {
 				'default'     => '',
 				'label_block' => false,
 				'description' => __( 'Note: This will override the `Choose Form` field', 'jet-form-builder' ),
-				'dynamic'     => array( 'active' => true, ),
+				'dynamic'     => array( 'active' => true ),
 			)
 		);
 

--- a/includes/blocks/types/form.php
+++ b/includes/blocks/types/form.php
@@ -95,6 +95,10 @@ class Form extends Base {
 	 * @return false|string [type]             [description]
 	 */
 	public function render_form( array $attrs, $content = null, $wp_block = null ) {
+		if ( ! empty( $attrs['form_id_custom'] ) ) {
+			$attrs['form_id'] = $attrs['form_id_custom'];
+		}
+
 		$form_id = absint( $attrs['form_id'] ?? 0 );
 
 		if ( ! $form_id ) {


### PR DESCRIPTION
Added a ‘Form ID’ control that will override the 'Choose Form' field when set. This control supports dynamic values via Elementor's 'Dynamic Tags' feature.

<img width="394" alt="Screenshot 2024-09-04 at 15 08 42" src="https://github.com/user-attachments/assets/c1701936-6f62-4605-8f8a-234c29c39795">