### PR TITLE
FIX: rest validation endpoint does not accept 0 as form input

### DIFF
--- a/modules/validation/rest-api/rest-validation-endpoint.php
+++ b/modules/validation/rest-api/rest-validation-endpoint.php
@@ -61,7 +61,7 @@ class Rest_Validation_Endpoint extends Rest_Api\Rest_Api_Endpoint_Base {
 			array( 'rules', $body[ self::RULE_INDEX_KEY ] )
 		);
 
-		if ( ! $parser->get_value() || empty( $ssr_attrs['value'] ) ) {
+		if ( null === $parser->get_value() || '' === $parser->get_value() || empty( $ssr_attrs['value'] ) ) {
 			return new \WP_REST_Response(
 				array(
 					'message' => __( 'Field value or callback is empty', 'jet-form-builder' ),


### PR DESCRIPTION
When using a advanced form field validation rule of type server-side callback the  rest validation endpoint will terminate the request with a http code 400 when a 0 is passed as the form field value.