### PR TITLE
Change get_values method to return 'value' key

### DIFF
--- a/modules/post-type/meta/messages-meta.php
+++ b/modules/post-type/meta/messages-meta.php
@@ -95,7 +95,7 @@ class Messages_Meta extends Base_Meta_Type {
 
 
 	public function get_values() {
-		return $this->get_by_key( 'label' );
+		return $this->get_by_key( 'value' );
 	}
 
 	public function get_labels(): array {


### PR DESCRIPTION
a minor bug fix, the get get_values function was returning the label,
fixed it to return the value instead
Before, when returning the label
<img width="299" height="709" alt="image" src="https://github.com/user-attachments/assets/dcb066a3-c03c-406f-8d1b-857e9865ef43" />
Now, after fixing the function
<img width="291" height="692" alt="image" src="https://github.com/user-attachments/assets/659821e5-f100-44af-b8c8-c7d625da068c" />
 